### PR TITLE
Set controller channel to 3.4 in CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,7 +35,7 @@ jobs:
     with:
       command: ${{ matrix.command }}
       juju-channel: "3.4/stable"
-      nested-containers: True
+      nested-containers: false
       provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,6 +10,10 @@ on:
       - "**.md"
       - "**.rst"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-unit:
     uses: canonical/bootstack-actions/.github/workflows/lint-unit.yaml@v2
@@ -19,27 +23,19 @@ jobs:
         python-version: ["3.8", "3.10"]
     with:
       python-version: ${{ matrix.python-version }}
-      tox-version: "<4"
       working-directory: .
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
     needs: lint-unit
     strategy:
       fail-fast: false
+      matrix:
+        command: ['TEST_JUJU3=1 make functional']  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
     with:
-      command: "make functional"
-      juju-channel: "2.9/stable"
+      command: ${{ matrix.command }}
+      juju-channel: "3.4/stable"
+      nested-containers: True
       provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120
-      tox-version: "<4"
-      runs-on: "['self-hosted', 'runner-nrpe']"
-      action-operator: false
-      external-controller: true
-      juju-controller: soleng-ci-ctrl-29
-      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkLTI5CmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtMjktY3JlZAo="
-    secrets:
-      juju-controllers-yaml: ${{ secrets.JUJU_CONTROLLERS_YAML }}
-      juju-accounts-yaml: ${{ secrets.JUJU_ACCOUNTS_YAML }}
-      openstack-auth-env: ${{ secrets.OPENSTACK_AUTH_ENV }}

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,10 @@ submodules-update:
 	@echo "Pulling latest updates for submodules"
 	@git submodule update --init --recursive --remote --merge
 
-build:
-	@echo "Building charm to base directory ${CHARM_BUILD_DIR}/${CHARM_NAME}.charm"
-	@-git rev-parse --abbrev-ref HEAD > ./repo-info
-	@-git describe --always > ./version
-	@tox -e build
+build: clean
+	@echo "Building charm"
+	@charmcraft -v pack ${BUILD_ARGS}
+	@bash -c ./rename.sh
 
 release: clean build
 	@charmcraft upload nrpe.charm --release edge

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ help:
 	@echo ""
 
 clean:
-	@echo "Cleaning files"
-	@git clean -ffXd -e '!.idea'
 	@echo "Cleaning existing build"
-	@rm -rf ${CHARM_BUILD_DIR}/${CHARM_NAME}
+	@rm -rf ${PROJECTPATH}/${CHARM_NAME}*.charm
+	@echo "Cleaning charmcraft"
+	@charmcraft clean
 
 submodules:
 	@echo "Cloning submodules"
@@ -64,8 +64,9 @@ unittests:
 	@tox -e unit
 
 functional: build
-	@echo "Executing functional tests in ${CHARM_BUILD_DIR}"
-	@CHARM_BUILD_DIR=${CHARM_BUILD_DIR} tox -e func
+	@echo "Executing functional tests with ${PROJECTPATH}/${CHARM_NAME}.charm"
+	@CHARM_LOCATION=${PROJECTPATH} tox -e func -- ${FUNC_ARGS}
+
 
 test: lint proof unittests functional
 	@echo "Charm ${CHARM_NAME} has been tested"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,7 +27,3 @@ requires:
   local-monitors:
     interface: local-monitors
     scope: container
-series:
-  - jammy
-  - focal
-  - bionic

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
+git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
 python-openstackclient

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
+git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
 python-openstackclient

--- a/tests/functional/tests/bundles/base.yaml
+++ b/tests/functional/tests/bundles/base.yaml
@@ -3,7 +3,7 @@ applications:
   rabbitmq-server:
     charm: ch:rabbitmq-server
     num_units: 1
-    constraints: root-disk=8G cores=2
+    constraints: root-disk=8G cores=2 virt-type=virtual-machine
   container:
     charm: ch:ubuntu
     # temporary fix for https://github.com/juju-solutions/charm-ubuntu/issues/48

--- a/tests/functional/tests/bundles/base.yaml
+++ b/tests/functional/tests/bundles/base.yaml
@@ -15,6 +15,8 @@ applications:
     charm: ch:nagios
     num_units: 1
     series: bionic
+  nrpe:
+    charm: nrpe
 relations:
   - - rabbitmq-server:nrpe-external-master
     - nrpe:nrpe-external-master

--- a/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -1,3 +1,3 @@
 applications:
-  nrpe:
-    charm: "{{ CHARM_BUILD_DIR }}/{{ charm_name }}.charm"
+  {{ charm_name }}:
+    charm: "{{ CHARM_LOCATION }}/{{ charm_name }}.charm"

--- a/tests/functional/tests/nrpe_tests.py
+++ b/tests/functional/tests/nrpe_tests.py
@@ -211,13 +211,13 @@ class TestNrpe(TestBase):
     @RETRY
     def test_05_netlinks(self):
         """Check netlinks checks are applied."""
-        netlinks = "- ens3 mtu:9000 speed:10000"
+        netlinks = "- lxdbr0 mtu:1500 speed:1000"
         model.set_application_config(self.application_name, {"netlinks": netlinks})
         model.block_until_all_units_idle()
-        cmd = "cat /etc/nagios/nrpe.d/check_netlinks_ens3.cfg"
+        cmd = "cat /etc/nagios/nrpe.d/check_netlinks_lxdbr0.cfg"
         line = (
-            "command[check_netlinks_ens3]=/usr/local/lib/nagios/plugins/"
-            "check_netlinks.py -i ens3 -m 9000 -s 1000"
+            "command[check_netlinks_lxdbr0]=/usr/local/lib/nagios/plugins/"
+            "check_netlinks.py -i lxdbr0 -m 1500 -s 1000"
         )
         result = model.run_on_unit(self.lead_unit_name, cmd)
         code = result.get("Code")
@@ -225,7 +225,7 @@ class TestNrpe(TestBase):
         if code != "0":
             logging.warning(
                 "Unable to find nrpe check at "
-                "/etc/nagios/nrpe.d/check_netlinks_ens3.cfg"
+                "/etc/nagios/nrpe.d/check_netlinks_lxdbr0.cfg"
             )
             raise model.CommandRunFailed(cmd, result)
         content = result.get("Stdout")
@@ -249,7 +249,7 @@ class TestNrpe(TestBase):
                 "swap_activity": "-i 5 -w 10240 -c 40960",
                 "mem": "-C -h -u -w 85 -c 90",
                 "lacp_bonds": "lo",  # Enable a bogus lacp check on the loopback iface
-                "netlinks": "- ens3 mtu:9000 speed:10000",
+                "netlinks": "- lxdbr0 mtu:1500 speed:1000",
                 "xfs_errors": "5",
             },
         )
@@ -272,7 +272,7 @@ class TestNrpe(TestBase):
                 "check_lacp_lo.cfg",
                 "check_load.cfg",
                 "check_mem.cfg",
-                "check_netlinks_ens3.cfg",
+                "check_netlinks_lxdbr0.cfg",
                 "check_ro_filesystem.cfg",
                 "check_swap.cfg",
                 "check_swap_activity.cfg",

--- a/tox.ini
+++ b/tox.ini
@@ -79,8 +79,8 @@ deps = -r{toxinidir}/tests/unit/requirements.txt
 
 [testenv:func]
 changedir = {toxinidir}/tests/functional
-commands = functest-run-suite --keep-faulty-model {posargs}
-deps = -r{toxinidir}/tests/functional/requirements.txt
+commands = functest-run-suite {posargs:--keep-faulty-model}
+deps = -r {toxinidir}/tests/functional/requirements.txt
 
 [testenv:build]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
 passenv =
   HOME
   PATH
-  CHARM_BUILD_DIR
+  CHARM_LOCATION
   PYTEST_KEEP_MODEL
   PYTEST_CLOUD_NAME
   PYTEST_CLOUD_REGION
@@ -81,11 +81,3 @@ deps = -r{toxinidir}/tests/unit/requirements.txt
 changedir = {toxinidir}/tests/functional
 commands = functest-run-suite {posargs:--keep-faulty-model}
 deps = -r {toxinidir}/tests/functional/requirements.txt
-
-[testenv:build]
-basepython = python3
-deps = -r{toxinidir}/build-requirements.txt
-commands =
-    charmcraft clean
-    charmcraft -v pack
-    {toxinidir}/rename.sh


### PR DESCRIPTION
Switching CI run with Juju 3.4 and on LXD, with VM instead of container. Running on top of LXD required some changes on two functional tests.

Add workflow concurrency to avoid running multiple workflows on a single PR. Like this if new commit arrived the previous run will be canceled by new run.

~~Blocked until [#655](https://github.com/openstack-charmers/zaza/pull/655) is merged.~~