### PR TITLE
Switch to support juju 3.1

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       fail-fast: false
     with:
-      command: "make functional"
-      juju-channel: "2.9/stable"
+      command: "TEST_JUJU3=1 make functional"
+      juju-channel: "3.1/stable"
       provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120
@@ -37,8 +37,8 @@ jobs:
       runs-on: "['self-hosted', 'runner-nrpe']"
       action-operator: false
       external-controller: true
-      juju-controller: soleng-ci-ctrl-29
-      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkLTI5CmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtMjktY3JlZAo="
+      juju-controller: soleng-ci-ctrl
+      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkCmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtY3JlZAo="
     secrets:
       juju-controllers-yaml: ${{ secrets.JUJU_CONTROLLERS_YAML }}
       juju-accounts-yaml: ${{ secrets.JUJU_ACCOUNTS_YAML }}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 PYTHON := /usr/bin/python3
 
 PROJECTPATH=$(dir $(realpath $(MAKEFILE_LIST)))
-ifndef CHARM_BUILD_DIR
-	CHARM_BUILD_DIR=${PROJECTPATH}
-endif
 METADATA_FILE="metadata.yaml"
 CHARM_NAME=$(shell cat ${PROJECTPATH}/${METADATA_FILE} | grep -E '^name:' | awk '{print $$2}')
 
@@ -39,10 +36,11 @@ submodules-update:
 	@git submodule update --init --recursive --remote --merge
 
 build:
-	@echo "Building charm to base directory ${CHARM_BUILD_DIR}/${CHARM_NAME}.charm"
+	@echo "Building charm to base directory ${PROJECTPATH}/${CHARM_NAME}.charm"
 	@-git rev-parse --abbrev-ref HEAD > ./repo-info
 	@-git describe --always > ./version
-	@tox -e build
+	@charmcraft -v pack ${BUILD_ARGS}
+	@bash -c ./rename.sh
 
 release: clean build
 	@charmcraft upload nrpe.charm --release edge

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ help:
 	@echo ""
 
 clean:
-	@echo "Cleaning files"
-	@git clean -ffXd -e '!.idea'
 	@echo "Cleaning existing build"
-	@rm -rf ${CHARM_BUILD_DIR}/${CHARM_NAME}
+	@rm -rf ${PROJECTPATH}/${CHARM_NAME}*.charm
+	@echo "Cleaning charmcraft"
+	@charmcraft clean
 
 submodules:
 	@echo "Cloning submodules"
@@ -64,8 +64,9 @@ unittests:
 	@tox -e unit
 
 functional: build
-	@echo "Executing functional tests in ${CHARM_BUILD_DIR}"
-	@CHARM_BUILD_DIR=${CHARM_BUILD_DIR} tox -e func
+	@echo "Executing functional tests with ${PROJECTPATH}/${CHARM_NAME}.charm"
+	@CHARM_LOCATION=${PROJECTPATH} tox -e func -- ${FUNC_ARGS}
+
 
 test: lint proof unittests functional
 	@echo "Charm ${CHARM_NAME} has been tested"

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,7 +1,0 @@
-# NOTES(lourot):
-# * We don't install charmcraft via pip anymore because it anyway spins up a
-#   container and scp the system's charmcraft snap inside it. So the charmcraft
-#   snap is necessary on the system anyway.
-# * `tox -e build` successfully validated with charmcraft 1.2.1
-
-cffi==1.14.6; python_version < '3.6'  # cffi 1.15.0 drops support for py35.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,7 +27,3 @@ requires:
   local-monitors:
     interface: local-monitors
     scope: container
-series:
-  - jammy
-  - focal
-  - bionic

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
+git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
 python-openstackclient

--- a/tests/functional/tests/bundles/base.yaml
+++ b/tests/functional/tests/bundles/base.yaml
@@ -15,6 +15,8 @@ applications:
     charm: ch:nagios
     num_units: 1
     series: bionic
+  nrpe:
+    charm: nrpe
 relations:
   - - rabbitmq-server:nrpe-external-master
     - nrpe:nrpe-external-master

--- a/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -1,3 +1,3 @@
 applications:
-  nrpe:
-    charm: "{{ CHARM_BUILD_DIR }}/{{ charm_name }}.charm"
+  {{ charm_name }}:
+    charm: "{{ CHARM_LOCATION }}/{{ charm_name }}.charm"

--- a/tox.ini
+++ b/tox.ini
@@ -79,8 +79,8 @@ deps = -r{toxinidir}/tests/unit/requirements.txt
 
 [testenv:func]
 changedir = {toxinidir}/tests/functional
-commands = functest-run-suite --keep-faulty-model {posargs}
-deps = -r{toxinidir}/tests/functional/requirements.txt
+commands = functest-run-suite {posargs:--keep-faulty-model}
+deps = -r {toxinidir}/tests/functional/requirements.txt
 
 [testenv:build]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
 passenv =
   HOME
   PATH
-  CHARM_BUILD_DIR
+  CHARM_LOCATION
   PYTEST_KEEP_MODEL
   PYTEST_CLOUD_NAME
   PYTEST_CLOUD_REGION
@@ -81,11 +81,3 @@ deps = -r{toxinidir}/tests/unit/requirements.txt
 changedir = {toxinidir}/tests/functional
 commands = functest-run-suite {posargs:--keep-faulty-model}
 deps = -r {toxinidir}/tests/functional/requirements.txt
-
-[testenv:build]
-basepython = python3
-deps = -r{toxinidir}/build-requirements.txt
-commands =
-    charmcraft clean
-    charmcraft -v pack
-    {toxinidir}/rename.sh


### PR DESCRIPTION
Making switch to Juju 3.1 as middle step before switching to 3.4.

In this PR I also sanitized little bit the repo.

Blocked until [#655](https://github.com/openstack-charmers/zaza/pull/655) is not merged.