### PR TITLE
Add link to project site

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,7 @@ name: nrpe
 format: 2
 summary: Nagios Remote Plugin Executor Server
 maintainer: LMA Charmers <llama-charmers@lists.ubuntu.com>
+website: https://github.com/canonical/charm-nrpe
 subordinate: true
 docs: https://discourse.charmhub.io/t/nrpe-docs-index/11332
 description: |


### PR DESCRIPTION
It's now on github.  I updated the homepage link on charmhub directly so it's fixed immediately, but it's good to get it officially in the metadata.

Fixes #168 