### PR TITLE
Ensure charmhelpers is included in build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # charmhelpers library is a submodule
           submodules: true
       - name: Initialize lxd  # This should dropped once it's implemented on charming-actions itself. https://github.com/canonical/charming-actions/issues/140
         uses: canonical/setup-lxd@v0.1.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,11 @@ make unittests       # unit tests
 make functional      # functional tests
 ```
 
+NOTE: this repository includes submodules.
+It is important that these are checked out before building or testing the charm.
+The `build` make target will init and update the submodules as a dependency,
+or you can manually run `make submodules` or use the `git submodule` commands directly.
+
 ## Build the charm
 
 Build the charm in this git repository using:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ submodules-update:
 	@echo "Pulling latest updates for submodules"
 	@git submodule update --init --recursive --remote --merge
 
-build: clean
+build: clean submodules
 	@echo "Building charm"
 	@charmcraft -v pack ${BUILD_ARGS}
 	@bash -c ./rename.sh


### PR DESCRIPTION
charmhelpers library is a git submodule, so we must update git submodules after checking out the repo for building the charm.

Moreover, it's necessary to have the submodule to be able to run unit tests, so added this info on CONTRIBUTING.md