### PR TITLE
Add tailoring file for cis audit

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -286,17 +286,18 @@ options:
     description: |
       Verify that a specific cis audit profile was used for the audit. If not specified the
       profile will be extracted from '/var/log/cloud-init-output.log', fallback is 'level1_server'.
-      Options are: '' (disable profile check), 'level1_server', 'level2_server',
-                   'level1_workstation' or 'level2_workstation'
-      This option cannot be used with cis_audit_tailoringfile at the same time.
+      To see the valid options to this configuration, check the documentation at
+      https://ubuntu.com/security/certifications/docs/usg/cis/compliance
+      This option cannot be used with cis_audit_tailoringfile at the same time, otherwise the charm
+      blocks.
       See also https://ubuntu.com/security/certifications/docs/cis-audit
   cis_audit_tailoringfile:
     default: ""
     type: string
     description: |
-      Custom cis profile xml file. The content of the file will be placed at
+      Custom cis profile xml file content. The content will be saved in
       /etc/usg/default-tailoring.xml. This option cannot be used with cis_audit_profile at the
-      same time.
+      same time, otherwise the charm blocks.
       See also https://ubuntu.com/blog/cis-security-compliance-usg
   reboot:
     default: True

--- a/config.yaml
+++ b/config.yaml
@@ -288,7 +288,16 @@ options:
       profile will be extracted from '/var/log/cloud-init-output.log', fallback is 'level1_server'.
       Options are: '' (disable profile check), 'level1_server', 'level2_server',
                    'level1_workstation' or 'level2_workstation'
+      This option cannot be used with cis_audit_tailoringfile at the same time.
       See also https://ubuntu.com/security/certifications/docs/cis-audit
+  cis_audit_tailoringfile:
+    default: ""
+    type: string
+    description: |
+      Custom cis profile xml file. The content of the file will be placed at
+      /etc/usg/default-tailoring.xml. This option cannot be used with cis_audit_profile at the
+      same time.
+      See also https://ubuntu.com/blog/cis-security-compliance-usg
   reboot:
     default: True
     type: boolean

--- a/config.yaml
+++ b/config.yaml
@@ -285,12 +285,18 @@ options:
     type: string
     description: |
       Verify that a specific cis audit profile was used for the audit. If not specified the
-      profile will be extracted from '/var/log/cloud-init-output.log', fallback is 'level1_server'.
-      To see the valid options to this configuration, check the documentation at
-      https://ubuntu.com/security/certifications/docs/usg/cis/compliance
+      profile will be extracted from '/var/log/cloud-init-output.log'.
+      Options are:
+        Ubuntu series < focal:  '' (disable profile check), 'level1_server', 'level2_server',
+          'level1_workstation' or 'level2_workstation'
+        Ubuntu series >= focal: '' (disable profile check), 'cis_level1_server',
+          'cis_level2_server', 'cis_level1_workstation' or 'cis_level2_workstation'
+
       This option cannot be used with cis_audit_tailoringfile at the same time, otherwise the charm
       blocks.
-      See also https://ubuntu.com/security/certifications/docs/cis-audit
+      See the docs:
+        https://ubuntu.com/security/certifications/docs/cis-audit
+        https://ubuntu.com/security/certifications/docs/usg/cis/compliance
   cis_audit_tailoringfile:
     default: ""
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -285,19 +285,11 @@ options:
     type: string
     description: |
       Verify that a specific cis audit profile was used for the audit. If not specified the
-      profile will be extracted from '/var/log/cloud-init-output.log'.
-      Options are:
-        Ubuntu series < focal:  '' (disable profile check), 'level1_server', 'level2_server',
-          'level1_workstation' or 'level2_workstation'
-        Ubuntu series >= focal: '' (disable profile check), 'cis_level1_server',
-          'cis_level2_server', 'cis_level1_workstation' or 'cis_level2_workstation'
-
-      This option cannot be used with cis_audit_tailoringfile at the same time, otherwise the charm
-      blocks.
-      See the docs:
-        https://ubuntu.com/security/certifications/docs/cis-audit
-        https://ubuntu.com/security/certifications/docs/usg/cis/compliance
-  cis_audit_tailoringfile:
+      profile will be extracted from '/var/log/cloud-init-output.log', fallback is 'level1_server'.
+      Options are: '' (disable profile check), 'level1_server', 'level2_server',
+                   'level1_workstation' or 'level2_workstation'
+      See also https://ubuntu.com/security/certifications/docs/cis-audit
+  cis_audit_tailoring_file:
     default: ""
     type: string
     description: |

--- a/files/plugins/cron_cis_audit.py
+++ b/files/plugins/cron_cis_audit.py
@@ -75,7 +75,7 @@ def _get_cis_hardening_profile(profile):
     for _, line in enumerate(open(CLOUD_INIT_LOG)):
         for match in re.finditer(pattern, line):
             level, machine_type = match.groups()
-            return ["level{}_{}".format(level, machine_type)]
+            return "level{}_{}".format(level, machine_type)
 
     return DEFAULT_PROFILE
 

--- a/hooks/nrpe_helpers.py
+++ b/hooks/nrpe_helpers.py
@@ -902,11 +902,8 @@ def _get_cis_audit_check():
     return cis_audit_check
 
 
-def cis_misconfiguration():
-    """Check if CIS config are misconfigured.
-
-    if profile and tailoring file are used at the same time.
-    """
+def is_cis_misconfigured():
+    """Check if CIS config are misconfigured."""
     if hookenv.config("cis_audit_profile") and hookenv.config(
         "cis_audit_tailoringfile"
     ):
@@ -937,13 +934,15 @@ def cis_cmd_params(include_score=False):
     cmd_params = []
 
     profile = hookenv.config("cis_audit_profile")
-    cmd_params.append(f"-p {profile}" if profile else "")
+    if profile:
+        cmd_params.append(f"-p {profile}")
 
     cis_tailoring_file_handler()
     tailoring = hookenv.config("cis_audit_tailoringfile")
-    cmd_params.append("-t" if tailoring else "")
+    if tailoring:
+        cmd_params.append("-t")
 
     if include_score:
         cmd_params.append(hookenv.config("cis_audit_score"))
 
-    return " ".join(cmd for cmd in cmd_params if cmd)
+    return " ".join(cmd_params)

--- a/hooks/nrpe_helpers.py
+++ b/hooks/nrpe_helpers.py
@@ -903,9 +903,12 @@ def _get_cis_audit_check():
 
 
 def is_cis_misconfigured():
-    """Check if CIS config are misconfigured."""
+    """Check if CIS config is misconfigured.
+
+    Return True if CIS config is invalid, otherwise return False.
+    """
     if hookenv.config("cis_audit_profile") and hookenv.config(
-        "cis_audit_tailoringfile"
+        "cis_audit_tailoring_file"
     ):
         return True
 
@@ -916,14 +919,14 @@ def cis_tailoring_file_handler():
     """Handle the tailoring file depending on the configuration.
 
     When tailoring file is passed, creates a file at the default location with
-    the content passed on cis_audit_tailoringfile charm config.
+    the content passed on cis_audit_tailoring_file charm config.
 
     Case tailoring file is not used, ensure that the file is erased
     to not overlap with the profile passed.
     """
-    if hookenv.config("cis_audit_tailoringfile"):
+    if hookenv.config("cis_audit_tailoring_file"):
         TAILORING_CIS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        TAILORING_CIS_FILE.write_text(hookenv.config("cis_audit_tailoringfile"))
+        TAILORING_CIS_FILE.write_text(hookenv.config("cis_audit_tailoring_file"))
         return
 
     TAILORING_CIS_FILE.unlink(missing_ok=True)
@@ -938,7 +941,7 @@ def cis_cmd_params(include_score=False):
         cmd_params.append(f"-p {profile}")
 
     cis_tailoring_file_handler()
-    tailoring = hookenv.config("cis_audit_tailoringfile")
+    tailoring = hookenv.config("cis_audit_tailoring_file")
     if tailoring:
         cmd_params.append("-t")
 

--- a/hooks/nrpe_utils.py
+++ b/hooks/nrpe_utils.py
@@ -233,11 +233,12 @@ def update_cis_audit_cronjob(service_name):
 
         return
 
+    cis_cmd = nrpe_helpers.cis_cmd_params()
     file = "/usr/local/lib/nagios/plugins/cron_cis_audit.py"
-    profile = hookenv.config("cis_audit_profile")
-    cronjob = "*/10 * * * * root ({} -p '{}') 2>&1 | logger -t {}\n"
+
+    cronjob = f"*/10 * * * * root ({file} {cis_cmd}) 2>&1 | logger -t cron_cis_audit\n"
     with open(crond_file, "w") as crond_fd:
-        crond_fd.write(cronjob.format(file, profile, "cron_cis_audit"))
+        crond_fd.write(cronjob)
         hookenv.log("Cronjob configured at {}".format(crond_file), hookenv.DEBUG)
 
 

--- a/hooks/services.py
+++ b/hooks/services.py
@@ -105,7 +105,7 @@ def manage():
             status_set("blocked", "Nagios server not configured or related")
         elif nrpe_helpers.has_netlinks_error():
             status_set("blocked", "Netlinks parsing encountered failure; see logs")
-        elif nrpe_helpers.cis_misconfiguration():
+        elif nrpe_helpers.is_cis_misconfigured():
             status_set(
                 "blocked",
                 "You cannot provide both a tailoring file and a profile for CIS audit!",

--- a/hooks/services.py
+++ b/hooks/services.py
@@ -105,5 +105,10 @@ def manage():
             status_set("blocked", "Nagios server not configured or related")
         elif nrpe_helpers.has_netlinks_error():
             status_set("blocked", "Netlinks parsing encountered failure; see logs")
+        elif nrpe_helpers.cis_misconfiguration():
+            status_set(
+                "blocked",
+                "You cannot provide both a tailoring file and a profile for CIS audit!",
+            )
         else:
             status_set("active", "Ready{}".format(get_revision()))

--- a/hooks/services.py
+++ b/hooks/services.py
@@ -108,7 +108,8 @@ def manage():
         elif nrpe_helpers.is_cis_misconfigured():
             status_set(
                 "blocked",
-                "You cannot provide both cis_audit_profile and cis_audit_tailoring_file",
+                "You cannot provide both cis_audit_profile "
+                "and cis_audit_tailoring_file",
             )
         else:
             status_set("active", "Ready{}".format(get_revision()))

--- a/hooks/services.py
+++ b/hooks/services.py
@@ -108,7 +108,7 @@ def manage():
         elif nrpe_helpers.is_cis_misconfigured():
             status_set(
                 "blocked",
-                "You cannot provide both a tailoring file and a profile for CIS audit!",
+                "You cannot provide both cis_audit_profile and cis_audit_tailoring_file",
             )
         else:
             status_set("active", "Ready{}".format(get_revision()))

--- a/tests/unit/test_nrpe_helpers.py
+++ b/tests/unit/test_nrpe_helpers.py
@@ -615,7 +615,7 @@ class TestCISAuditCheck(unittest.TestCase):
         mock_tailor_handler.assert_not_called()
 
     @mock.patch("nrpe_helpers.hookenv.config")
-    def test_cis_misconfiguration(self, mock_config):
+    def test_is_cis_misconfigured(self, mock_config):
         """Test that is misconfigured if user pass profile and tailoring file."""
         config = {
             "cis_audit_profile": "level1_server",
@@ -624,7 +624,30 @@ class TestCISAuditCheck(unittest.TestCase):
         }
         mock_config.side_effect = lambda key: config[key]
 
-        self.assertTrue(nrpe_helpers.cis_misconfiguration())
+        self.assertTrue(nrpe_helpers.is_cis_misconfigured())
+
+    @mock.patch("nrpe_helpers.hookenv.config")
+    def test_cis_not_misconfigured(self, mock_config):
+        """Test that is misconfigured if user pass profile and tailoring file."""
+        # using just the tailoring file
+        config = {
+            "cis_audit_profile": "",
+            "cis_audit_score": "-w 85 -c 80",
+            "cis_audit_tailoringfile": "my xml content",
+        }
+        mock_config.side_effect = lambda key: config[key]
+
+        self.assertFalse(nrpe_helpers.is_cis_misconfigured())
+
+        # using just the profile
+        config = {
+            "cis_audit_profile": "level1_server",
+            "cis_audit_score": "-w 85 -c 80",
+            "cis_audit_tailoringfile": "",
+        }
+        mock_config.side_effect = lambda key: config[key]
+
+        self.assertFalse(nrpe_helpers.is_cis_misconfigured())
 
     @mock.patch("nrpe_helpers.TAILORING_CIS_FILE")
     @mock.patch("nrpe_helpers.hookenv.config")

--- a/tests/unit/test_nrpe_helpers.py
+++ b/tests/unit/test_nrpe_helpers.py
@@ -593,7 +593,7 @@ class TestCISAuditCheck(unittest.TestCase):
             "cis_audit_enabled": True,
             "cis_audit_profile": "level1_server",
             "cis_audit_score": "-w 85 -c 80",
-            "cis_audit_tailoringfile": "",
+            "cis_audit_tailoring_file": "",
         }
         mock_config.side_effect = lambda key: config[key]
         expected_check = {
@@ -620,7 +620,7 @@ class TestCISAuditCheck(unittest.TestCase):
         config = {
             "cis_audit_profile": "level1_server",
             "cis_audit_score": "-w 85 -c 80",
-            "cis_audit_tailoringfile": "my xml content",
+            "cis_audit_tailoring_file": "my xml content",
         }
         mock_config.side_effect = lambda key: config[key]
 
@@ -633,7 +633,7 @@ class TestCISAuditCheck(unittest.TestCase):
         config = {
             "cis_audit_profile": "",
             "cis_audit_score": "-w 85 -c 80",
-            "cis_audit_tailoringfile": "my xml content",
+            "cis_audit_tailoring_file": "my xml content",
         }
         mock_config.side_effect = lambda key: config[key]
 
@@ -643,7 +643,7 @@ class TestCISAuditCheck(unittest.TestCase):
         config = {
             "cis_audit_profile": "level1_server",
             "cis_audit_score": "-w 85 -c 80",
-            "cis_audit_tailoringfile": "",
+            "cis_audit_tailoring_file": "",
         }
         mock_config.side_effect = lambda key: config[key]
 
@@ -656,7 +656,7 @@ class TestCISAuditCheck(unittest.TestCase):
         config = {
             "cis_audit_profile": "level1_server",
             "cis_audit_score": "-w 85 -c 80",
-            "cis_audit_tailoringfile": "",
+            "cis_audit_tailoring_file": "",
         }
         mock_config.side_effect = lambda key: config[key]
 
@@ -670,7 +670,7 @@ class TestCISAuditCheck(unittest.TestCase):
         config = {
             "cis_audit_profile": "",
             "cis_audit_score": "-w 85 -c 80",
-            "cis_audit_tailoringfile": "my xml content",
+            "cis_audit_tailoring_file": "my xml content",
         }
         mock_config.side_effect = lambda key: config[key]
 
@@ -685,7 +685,7 @@ class TestCISAuditCheck(unittest.TestCase):
             "cis_audit_enabled": True,
             "cis_audit_profile": "level1_server",
             "cis_audit_score": "-w 85 -c 80",
-            "cis_audit_tailoringfile": "",
+            "cis_audit_tailoring_file": "",
         }
         mock_config.side_effect = lambda key: config[key]
         # include score
@@ -705,7 +705,7 @@ class TestCISAuditCheck(unittest.TestCase):
         config = {
             "cis_audit_profile": "",
             "cis_audit_score": "-w 85 -c 80",
-            "cis_audit_tailoringfile": "my xml content",
+            "cis_audit_tailoring_file": "my xml content",
         }
         mock_config.side_effect = lambda key: config[key]
         # include score

--- a/tests/unit/test_nrpe_helpers.py
+++ b/tests/unit/test_nrpe_helpers.py
@@ -614,7 +614,6 @@ class TestCISAuditCheck(unittest.TestCase):
         self.assertEqual(nrpe_helpers._get_cis_audit_check(), {})
         mock_tailor_handler.assert_not_called()
 
-
     @mock.patch("nrpe_helpers.hookenv.config")
     def test_cis_misconfiguration(self, mock_config):
         """Test that is misconfigured if user pass profile and tailoring file."""
@@ -629,9 +628,7 @@ class TestCISAuditCheck(unittest.TestCase):
 
     @mock.patch("nrpe_helpers.TAILORING_CIS_FILE")
     @mock.patch("nrpe_helpers.hookenv.config")
-    def test_cis_tailoring_file_handler_erase(
-        self, mock_config, mock_tailor
-    ):
+    def test_cis_tailoring_file_handler_erase(self, mock_config, mock_tailor):
         """Test that the file handler erase the tailoring file."""
         config = {
             "cis_audit_profile": "level1_server",
@@ -645,9 +642,7 @@ class TestCISAuditCheck(unittest.TestCase):
 
     @mock.patch("nrpe_helpers.TAILORING_CIS_FILE")
     @mock.patch("nrpe_helpers.hookenv.config")
-    def test_cis_tailoring_file_handler_write(
-        self, mock_config, mock_tailor
-    ):
+    def test_cis_tailoring_file_handler_write(self, mock_config, mock_tailor):
         """Test that the file handler write the tailoring file."""
         config = {
             "cis_audit_profile": "",

--- a/tests/unit/test_nrpe_helpers.py
+++ b/tests/unit/test_nrpe_helpers.py
@@ -628,7 +628,7 @@ class TestCISAuditCheck(unittest.TestCase):
 
     @mock.patch("nrpe_helpers.hookenv.config")
     def test_cis_not_misconfigured(self, mock_config):
-        """Test that is misconfigured if user pass profile and tailoring file."""
+        """Test that is not misconfigured if only pass profile or tailoring file."""
         # using just the tailoring file
         config = {
             "cis_audit_profile": "",

--- a/tests/unit/test_plugins_cis_audit.py
+++ b/tests/unit/test_plugins_cis_audit.py
@@ -101,7 +101,6 @@ class TestCronCisAudit(TestCase):
     @mock.patch("files.plugins.cron_cis_audit.TAILORING_CIS_FILE")
     def test_get_cis_hardening_profile_tailoring(self, mock_tailoring):
         """Test hardening profile when using tailoring file."""
-        # default profile should be return if profile passed is invalid
         mock_tailoring.exists.return_value = True
         profile = cron_cis_audit._get_cis_hardening_profile("")
         self.assertEqual(

--- a/tests/unit/test_plugins_cis_audit.py
+++ b/tests/unit/test_plugins_cis_audit.py
@@ -90,7 +90,7 @@ class TestCronCisAudit(TestCase):
     @mock.patch("files.plugins.cron_cis_audit.CLOUD_INIT_LOG", cloud_init_logfile)
     def test_get_cis_hardening_profile_cloudinit(self):
         """Test the detection of the hardening profile from cloudinit.log."""
-        expected_profile = ["level2_server"]
+        expected_profile = "level2_server"
         profile = cron_cis_audit._get_cis_hardening_profile("")
         self.assertEqual(
             profile,

--- a/tests/unit/test_plugins_cis_audit.py
+++ b/tests/unit/test_plugins_cis_audit.py
@@ -75,7 +75,7 @@ class TestCronCisAudit(TestCase):
         profile = cron_cis_audit._get_cis_hardening_profile("")
         self.assertEqual(
             profile,
-            [cron_cis_audit.DEFAULT_PROFILE],
+            cron_cis_audit.DEFAULT_PROFILE,
             "Default profile should have been returned",
         )
         # parameter should be returned if parameter contains a valid profile
@@ -83,7 +83,7 @@ class TestCronCisAudit(TestCase):
         profile = cron_cis_audit._get_cis_hardening_profile(expected_profile)
         self.assertEqual(
             profile,
-            [expected_profile],
+            expected_profile,
             "The profile in the parameter should have been returned",
         )
 
@@ -105,7 +105,7 @@ class TestCronCisAudit(TestCase):
         profile = cron_cis_audit._get_cis_hardening_profile("")
         self.assertEqual(
             profile,
-            [],
+            None,
             "No profile should have been returned",
         )
 
@@ -345,11 +345,11 @@ class TestCheckCisAudit(TestCase):
         """Test the parsing of the audit results file."""
         # empty file raises CriticalError
         with self.assertRaises(CriticalError):
-            check_cis_audit.get_audit_score_and_profile(self.bionic_testfile1)
+            check_cis_audit.get_audit_score_and_profile(self.bionic_testfile1, False)
 
         # score and profile correctly read from xml
         score, profile = check_cis_audit.get_audit_score_and_profile(
-            self.bionic_testfile2
+            self.bionic_testfile2, False
         )
         self.assertEqual(score, 89.444443)
         self.assertEqual(profile, "level1_server")
@@ -359,14 +359,28 @@ class TestCheckCisAudit(TestCase):
         """Test the parsing of the audit results file."""
         # empty file raises CriticalError
         with self.assertRaises(CriticalError):
-            check_cis_audit.get_audit_score_and_profile(self.focal_testfile1)
+            check_cis_audit.get_audit_score_and_profile(self.focal_testfile1, False)
 
         # score and profile correctly read from xml
         score, profile = check_cis_audit.get_audit_score_and_profile(
-            self.focal_testfile2
+            self.focal_testfile2, False
         )
         self.assertEqual(score, 66.160233)
         self.assertEqual(profile, "level1_server")
+
+    @mock.patch("files.plugins.check_cis_audit.PROFILE_MAP", focal_profile_map)
+    def test_get_audit_score_and_profile_tailoring(self):
+        """Test the parsing of the audit results file using a tailoring file."""
+        # empty file raises CriticalError
+        with self.assertRaises(CriticalError):
+            check_cis_audit.get_audit_score_and_profile(self.focal_testfile1, True)
+
+        # score and profile correctly read from xml
+        score, profile = check_cis_audit.get_audit_score_and_profile(
+            self.focal_testfile2, True
+        )
+        self.assertEqual(score, 66.160233)
+        self.assertEqual(profile, "default-tailoring-file")
 
     @mock.patch("sys.argv", [])
     def test_parse_args(self):
@@ -377,6 +391,7 @@ class TestCheckCisAudit(TestCase):
             arguments,
             argparse.Namespace(
                 cis_profile="",
+                tailoring=False,
                 crit=-1,
                 max_age=172,
                 warn=-1,
@@ -392,10 +407,32 @@ class TestCheckCisAudit(TestCase):
             argparse.Namespace(
                 cis_profile="level2_server",
                 crit=99,
+                tailoring=False,
                 max_age=1,
                 warn=90,
             ),
         )
+
+        # test setting tailoring
+        arguments = check_cis_audit.parse_args(
+            ["-a", "1", "-c", "99", "-w", "90", "-t"]
+        )
+        self.assertEqual(
+            arguments,
+            argparse.Namespace(
+                cis_profile="",
+                crit=99,
+                tailoring=True,
+                max_age=1,
+                warn=90,
+            ),
+        )
+
+        # test setting tailoring and profile at the same time
+        with self.assertRaises(SystemExit):
+            check_cis_audit.parse_args(
+                ["-a", "1", "-c", "99", "-w", "90", "-t", "-p", "level2_server"]
+            )
 
     @mock.patch.multiple(
         "files.plugins.check_cis_audit",
@@ -405,11 +442,11 @@ class TestCheckCisAudit(TestCase):
     def test_check_cis_audit(self):
         """Test the check function with different parameters."""
         # all ok
-        check_cis_audit.check_cis_audit("", 1, 80, 85)
+        check_cis_audit.check_cis_audit("", 1, False, 80, 85)
 
         # too old
         with self.assertRaises(CriticalError) as error:
-            check_cis_audit.check_cis_audit("", 0, 80, 85)
+            check_cis_audit.check_cis_audit("", 0, False, 80, 85)
         self.assertRegex(
             str(error.exception),
             "CRITICAL: The audit result file age 0.00h is older than threshold.*",
@@ -417,7 +454,7 @@ class TestCheckCisAudit(TestCase):
 
         # score below warning
         with self.assertRaises(WarnError) as error:
-            check_cis_audit.check_cis_audit("", 1, 90, 80)
+            check_cis_audit.check_cis_audit("", 1, False, 90, 80)
         self.assertRegex(
             str(error.exception),
             "WARNING: cis-audit score is 89.44 of 100; threshold -c 80 -w 90",
@@ -425,7 +462,7 @@ class TestCheckCisAudit(TestCase):
 
         # score below critical
         with self.assertRaises(CriticalError) as error:
-            check_cis_audit.check_cis_audit("", 1, 95, 90)
+            check_cis_audit.check_cis_audit("", 1, False, 95, 90)
         self.assertRegex(
             str(error.exception),
             "CRITICAL: cis-audit score is 89.44 of 100; threshold -c 90 -w 95",
@@ -433,7 +470,7 @@ class TestCheckCisAudit(TestCase):
 
         # profile does not match
         with self.assertRaises(CriticalError) as error:
-            check_cis_audit.check_cis_audit("level2_workstation", 1, 85, 80)
+            check_cis_audit.check_cis_audit("level2_workstation", 1, False, 85, 80)
         self.assertRegex(
             str(error.exception),
             "CRITICAL: requested audit profile 'level2_workstation' does not match",
@@ -446,6 +483,8 @@ class TestCheckCisAudit(TestCase):
     )
     def test_main(self):
         """Test the main function."""
-        namespace = argparse.Namespace(cis_profile="", max_age=1, crit=80, warn=70)
+        namespace = argparse.Namespace(
+            cis_profile="", max_age=1, tailoring=False, crit=80, warn=70
+        )
         with mock.patch("argparse.ArgumentParser.parse_args", return_value=namespace):
             check_cis_audit.main()


### PR DESCRIPTION
Added the new config cis_audit_tailoringfile to pass a custom tailoring file for CIS audit.

This new option is mutual exclusive with cis_audit_profile, meaning that you cannot use both at the same time.

When the tailoring file content is passed, the charm will write the content at the default place on /etc/usg/default-tailoring.xml

If the option is not used, the charm will ensure that this file doesn't exist to not interfere with the profile passed.

See the docs for more details:
[0](https://ubuntu.com/security/certifications/docs/usg/cis/customization) [1](https://ubuntu.com/blog/cis-security-compliance-usg)

Closes #186 