### PR TITLE
Fix available options for cis audit profile

### DIFF
--- a/files/plugins/check_cis_audit.py
+++ b/files/plugins/check_cis_audit.py
@@ -34,8 +34,10 @@ def _get_major_version():
     raise OSError("No VERSION_ID in /etc/os-release")
 
 
-# cis-audit changed between bionic and focal
-if _get_major_version() < 20:
+# cis audit changed from bionic to focal.
+DISTRO_VERSION = _get_major_version()
+
+if DISTRO_VERSION < 20:
     AUDIT_FOLDER = "/usr/share/ubuntu-scap-security-guides"
     AUDIT_RESULT_GLOB = AUDIT_FOLDER + "/cis-*-results.xml"
     PROFILE_MAP = {
@@ -44,6 +46,7 @@ if _get_major_version() < 20:
         "level1_workstation": "cis_profile_Level_1_Workstation",
         "level2_workstation": "cis_profile_Level_2_Workstation",
     }
+    PROFILE_OPTIONS = list(PROFILE_MAP.keys())
 else:
     AUDIT_FOLDER = "/var/lib/usg"
     AUDIT_RESULT_GLOB = AUDIT_FOLDER + "/usg-results-*.*.xml"
@@ -53,7 +56,7 @@ else:
         "level1_workstation": "cis_level1_workstation",
         "level2_workstation": "cis_level2_workstation",
     }
-
+    PROFILE_OPTIONS = list(PROFILE_MAP.values())
 
 def get_audit_result_filepath():
     """Get the path of the newest audit results file."""
@@ -149,13 +152,7 @@ def parse_args(args):
     parser.add_argument(
         "--cis-profile",
         "-p",
-        choices=[
-            "",
-            "level1_server",
-            "level2_server",
-            "level1_workstation",
-            "level2_workstation",
-        ],
+        choices=PROFILE_OPTIONS + [""],
         help="cis-audit level parameter (verifies if audit report matches)",
         default="",
     )

--- a/files/plugins/check_cis_audit.py
+++ b/files/plugins/check_cis_audit.py
@@ -58,6 +58,7 @@ else:
     }
     PROFILE_OPTIONS = list(PROFILE_MAP.values())
 
+
 def get_audit_result_filepath():
     """Get the path of the newest audit results file."""
     audit_files = glob.glob(AUDIT_RESULT_GLOB)

--- a/files/plugins/check_cis_audit.py
+++ b/files/plugins/check_cis_audit.py
@@ -34,10 +34,8 @@ def _get_major_version():
     raise OSError("No VERSION_ID in /etc/os-release")
 
 
-# cis audit changed from bionic to focal.
-DISTRO_VERSION = _get_major_version()
-
-if DISTRO_VERSION < 20:
+# cis-audit changed between bionic and focal
+if _get_major_version() < 20:
     AUDIT_FOLDER = "/usr/share/ubuntu-scap-security-guides"
     AUDIT_RESULT_GLOB = AUDIT_FOLDER + "/cis-*-results.xml"
     PROFILE_MAP = {

--- a/files/plugins/cron_cis_audit.py
+++ b/files/plugins/cron_cis_audit.py
@@ -23,7 +23,7 @@ def _get_major_version():
     raise OSError("No VERSION_ID in /etc/os-release")
 
 
-# cis audit changed from bionic ot focal.
+# cis audit changed from bionic to focal.
 PROFILES = [
     "level1_server",
     "level2_server",

--- a/tests/unit/test_plugins_cis_audit.py
+++ b/tests/unit/test_plugins_cis_audit.py
@@ -372,13 +372,14 @@ class TestCheckCisAudit(TestCase):
     @mock.patch("files.plugins.check_cis_audit.PROFILE_OPTIONS")
     @mock.patch("sys.stderr", new_callable=StringIO)
     def test_parse_args_wrong_profile(self, mock_stderr, profile_options):
+        """Test wrong profile cli arguments depending on the Ubuntu series."""
         # When on focal, profile options should have the "cis_" prefix
         profile_options.return_value = [
             "",
             "cis_level1_server",
             "cis_level2_server",
             "cis_level1_workstation",
-            "cis_level2_workstation"
+            "cis_level2_workstation",
         ]
         with self.assertRaises(SystemExit):
             check_cis_audit.parse_args(["-p", "level2_server"])
@@ -394,7 +395,7 @@ class TestCheckCisAudit(TestCase):
             "level1_server",
             "level2_server",
             "level1_workstation",
-            "level2_workstation"
+            "level2_workstation",
         ]
         with self.assertRaises(SystemExit):
             check_cis_audit.parse_args(["-p", "cis_level2_server"])


### PR DESCRIPTION
The cis_audit_profile options changed from bionic to focal and the options were not matching with usg what causesed the cron job to fail

Closes: #189