### PR TITLE
Fix available options for cis audit profile

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -289,6 +289,9 @@ options:
       Options are: '' (disable profile check), 'level1_server', 'level2_server',
                    'level1_workstation' or 'level2_workstation'
       See also https://ubuntu.com/security/certifications/docs/cis-audit
+      Note that because of compatibility between Ubuntu 18.04 and 20.04, profiles are not using the
+      'cis_' prefix, but internally the charm is using the right profiles. E.g: level1_server is
+      equivalent of cis_level1_server.
   cis_audit_tailoring_file:
     default: ""
     type: string

--- a/files/plugins/cron_cis_audit.py
+++ b/files/plugins/cron_cis_audit.py
@@ -25,7 +25,14 @@ def _get_major_version():
 
 
 # cis audit changed from bionic ot focal.
-PROFILES_COMPATIBILITY = {
+BIONIC_PROFILES = {
+    "level1_server": "level1_server",
+    "level2_server": "level2_server",
+    "level1_workstation": "level1_workstation",
+    "level2_workstation": "level2_workstation",
+}
+
+FOCAL_PROFILES = {
     "level1_server": "cis_level1_server",
     "level2_server": "cis_level2_server",
     "level1_workstation": "cis_level1_workstation",
@@ -59,11 +66,11 @@ def _get_cis_hardening_profile(profile):
     if TAILORING_CIS_FILE.exists():
         return None
 
-    profiles = _get_profile_by_ubuntu_series()
-    default_profile = profiles[0]
+    profiles = _valid_profiles_for_platform()
+    default_profile = profiles["level1_server"]
 
     if profile in profiles:
-        return profile
+        return profiles[profile]
 
     if not os.path.exists(CLOUD_INIT_LOG) or not os.access(CLOUD_INIT_LOG, os.R_OK):
         print(
@@ -82,11 +89,11 @@ def _get_cis_hardening_profile(profile):
     return default_profile
 
 
-def _get_profile_by_ubuntu_series():
-    """Get the valid profile options depending on the Ubuntu series."""
+def _valid_profiles_for_platform():
+    """Get the valid profiles options depending on the Ubuntu series."""
     if _get_major_version() < 20:
-        return list(PROFILES_COMPATIBILITY.keys())
-    return list(PROFILES_COMPATIBILITY.values())
+        return BIONIC_PROFILES
+    return FOCAL_PROFILES
 
 
 def _get_cis_result_age():

--- a/files/plugins/cron_cis_audit.py
+++ b/files/plugins/cron_cis_audit.py
@@ -58,7 +58,7 @@ TAILORING_CIS_FILE = Path("/etc/usg/default-tailoring.xml")
 
 
 def _get_cis_hardening_profile(profile):
-    """Try to read the cis profile from cloud init log or defaults to the first option.
+    """Try to read the cis profile from cloud init log or default to level1_server.
 
     If the "default" tailoring file exists in /etc/usg/default-tailoring.xml,
     no profile is passed.

--- a/files/plugins/cron_cis_audit.py
+++ b/files/plugins/cron_cis_audit.py
@@ -25,12 +25,13 @@ def _get_major_version():
 
 
 # cis audit changed from bionic ot focal.
-PROFILES = [
-    "level1_server",
-    "level2_server",
-    "level1_workstation",
-    "level2_workstation",
-]
+PROFILES_COMPATIBILITY = {
+    "level1_server": "cis_level1_server",
+    "level2_server": "cis_level2_server",
+    "level1_workstation": "cis_level1_workstation",
+    "level2_workstation": "cis_level2_workstation",
+}
+
 DISTRO_VERSION = _get_major_version()
 if DISTRO_VERSION < 20:
     AUDIT_FOLDER = "/usr/share/ubuntu-scap-security-guides"
@@ -39,12 +40,10 @@ if DISTRO_VERSION < 20:
 else:
     AUDIT_FOLDER = "/var/lib/usg/"
     AUDIT_RESULT_GLOB = AUDIT_FOLDER + "/usg-results-*.*.xml"
-    PROFILES = ["cis_" + p for p in PROFILES]
     AUDIT_BIN = ["/usr/sbin/usg", "audit"]
 
 
 CLOUD_INIT_LOG = "/var/log/cloud-init-output.log"
-DEFAULT_PROFILE = PROFILES[0]
 
 MAX_SLEEP = 600
 PID_FILENAME = "/tmp/cron_cis_audit.pid"
@@ -52,7 +51,7 @@ TAILORING_CIS_FILE = Path("/etc/usg/default-tailoring.xml")
 
 
 def _get_cis_hardening_profile(profile):
-    """Try to read the cis profile from cloud init log or default to level1_server.
+    """Try to read the cis profile from cloud init log or defaults to the first option.
 
     If the "default" tailoring file exists in /etc/usg/default-tailoring.xml,
     no profile is passed.
@@ -60,16 +59,19 @@ def _get_cis_hardening_profile(profile):
     if TAILORING_CIS_FILE.exists():
         return None
 
-    if profile in PROFILES:
+    profiles = _get_profile_by_ubuntu_series()
+    default_profile = profiles[0]
+
+    if profile in profiles:
         return profile
 
     if not os.path.exists(CLOUD_INIT_LOG) or not os.access(CLOUD_INIT_LOG, os.R_OK):
         print(
             "{} not existing/accessible, default to profile '{}'".format(
-                CLOUD_INIT_LOG, DEFAULT_PROFILE
+                CLOUD_INIT_LOG, default_profile
             )
         )
-        return DEFAULT_PROFILE
+        return default_profile
 
     pattern = re.compile(r"Applying Level-(1|2) scored (server|workstation)")
     for _, line in enumerate(open(CLOUD_INIT_LOG)):
@@ -77,7 +79,14 @@ def _get_cis_hardening_profile(profile):
             level, machine_type = match.groups()
             return "level{}_{}".format(level, machine_type)
 
-    return DEFAULT_PROFILE
+    return default_profile
+
+
+def _get_profile_by_ubuntu_series():
+    """Get the valid profile options depending on the Ubuntu series."""
+    if _get_major_version() < 20:
+        return list(PROFILES_COMPATIBILITY.keys())
+    return list(PROFILES_COMPATIBILITY.values())
 
 
 def _get_cis_result_age():
@@ -132,11 +141,16 @@ def parse_args(args):
         help="maximum age (h) of result file before running the audit (default 168)",
         default=168,
     )
-    profile_options = PROFILES + [""]
     parser.add_argument(
         "--cis-profile",
         "-p",
-        choices=profile_options,
+        choices=[
+            "",
+            "level1_server",
+            "level2_server",
+            "level1_workstation",
+            "level2_workstation",
+        ],
         default="",
         type=str,
         help="cis-audit level parameter (verifies if audit report matches)",

--- a/hooks/nrpe_helpers.py
+++ b/hooks/nrpe_helpers.py
@@ -25,6 +25,15 @@ local_plugin_dir = "/usr/local/lib/nagios/plugins/"
 DB_KEY_KNOWN_REBOOT_TIME = "known_reboot_time"
 db = unitdata.kv()
 
+# These are the valid options to keep compatibility on changes between bionic and focal
+VALID_CHARM_CIS_PROFILES = [
+    "",
+    "level1_server",
+    "level2_server",
+    "level1_workstation",
+    "level2_workstation",
+]
+
 
 def get_cmd_output(cmd):
     """Get shell command output in unicode string."""
@@ -905,14 +914,21 @@ def _get_cis_audit_check():
 def is_cis_misconfigured():
     """Check if CIS config is misconfigured.
 
-    Return True if CIS config is invalid, otherwise return False.
+    Return True and a message if CIS config is invalid, otherwise
+    return False with empty message.
     """
     if hookenv.config("cis_audit_profile") and hookenv.config(
         "cis_audit_tailoring_file"
     ):
-        return True
+        return (
+            True,
+            "You cannot provide both cis_audit_profile and cis_audit_tailoring_file",
+        )
 
-    return False
+    if hookenv.config("cis_audit_profile") not in VALID_CHARM_CIS_PROFILES:
+        return True, "Invalid cis_audit_profile"
+
+    return False, ""
 
 
 def cis_tailoring_file_handler():

--- a/hooks/services.py
+++ b/hooks/services.py
@@ -101,15 +101,12 @@ def manage():
         status_set("waiting", msg)
     else:
         manager.manage()
+        cis_misconfigured, cis_message = nrpe_helpers.is_cis_misconfigured()
         if not nrpe_utils.has_consumer():
             status_set("blocked", "Nagios server not configured or related")
         elif nrpe_helpers.has_netlinks_error():
             status_set("blocked", "Netlinks parsing encountered failure; see logs")
-        elif nrpe_helpers.is_cis_misconfigured():
-            status_set(
-                "blocked",
-                "You cannot provide both cis_audit_profile "
-                "and cis_audit_tailoring_file",
-            )
+        elif cis_misconfigured:
+            status_set("blocked", cis_message)
         else:
             status_set("active", "Ready{}".format(get_revision()))

--- a/hooks/update-status
+++ b/hooks/update-status
@@ -20,4 +20,3 @@ def update_status():
 
 if __name__ == '__main__':
     update_status()
-


### PR DESCRIPTION
The cis_audit_profile options changed from bionic to focal and the options were not matching with usg what causesed the cron job to fail.

Closes: #189