### PR TITLE
Fix listing and running checks with dashes in name

### DIFF
--- a/actions/run-nrpe-check
+++ b/actions/run-nrpe-check
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-check=$(action-get name | sed -e 's/-/_/g')
+check=$(action-get name | sed -e 's/-/./g' | sed -e 's/_/./g')
 
 nrpedir="/etc/nagios/nrpe.d"
-checkfile="$nrpedir/${check}.cfg"
+checkfile_regex="$nrpedir/${check}.cfg"
+find_file_result=$(find $nrpedir -regex $checkfile_regex | wc -l)
+checkfile=$(find $nrpedir -regex $checkfile_regex)
 
-if [ -f $checkfile ]; then
+if [ $find_file_result -eq 1 ]; then
     command=$(grep command $checkfile | sed -e "s/command\[.*\]=//")
     output=$(echo $command | xargs sudo -u nagios)
     action-set check-output="$output"
 else
-    action-fail "$checkfile does not exist or the check failed"
+    action-fail "Regex search for $checkfile_regex did not find any entries, \
+or found multiple entries, or the check failed"
 fi
+


### PR DESCRIPTION
Fix running checks with both dashes and underscores in name

The "list-nrpe-checks" action converts underscores
to dashes because of key:value juju action result
structure, and "run-nrpe-check" converts dashes back
to underscores when specifying a check name with dashes.
However, if a check name has both dashes and underscores,
running the action with the listed check name will never
work.

This patch using regex search to find the name of the file
ignoring dashes and underscores, so it will find the check file
in all 3 scenarios. In case there are multiple results it returns
an error.

Closes: #212
