### PR TITLE
Update workflow to release the tested charms

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -136,6 +136,15 @@ jobs:
           TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653
           TEST_JUJU_CHANNEL: ${{ matrix.juju-channel }}
 
+      - name: Determine system architecture
+        run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
+
+      - name: Upload the tested charms
+        uses: actions/upload-artifact@v4
+        with:
+          name: built_charms_${{ env.SYSTEM_ARCH }}
+          path: ./*.charm
+
       # Save output for debugging
 
       - name: Generate debugging information

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,28 +16,29 @@ jobs:
     uses: ./.github/workflows/check.yaml
     secrets: inherit
 
+
   release:
     needs: check
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [[ubuntu-22.04]]
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
 
-      - name: Initialize lxd  # This should dropped once it's implemented on charming-actions itself. https://github.com/canonical/charming-actions/issues/140
-        # revision is latest main at time of writing; using because it contains a fix to https://github.com/canonical/setup-lxd/issues/19
-        uses: canonical/setup-lxd@2aa6f7caf7d1484298a64192f7f63a6684e648a4
+      - name: Download the tested charms
+        uses: actions/download-artifact@v4
+        with:
+          pattern: built_charms_*
+          merge-multiple: true
+
+      - name: List the names of the tested charms
+        run: |
+          echo "CHARM_NAMES=$(ls *.charm | paste -sd ,)" | tee -a "$GITHUB_ENV"
 
       - name: Pack and upload to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
-          charmcraft-channel: "3.x/stable"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          # Ensure the charm is built in an isolated environment and on the correct base in an lxd container.
-          destructive-mode: false
+          built-charm-path: "${{ env.CHARM_NAMES }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           echo "CHARM_NAMES=$(ls *.charm | paste -sd ,)" | tee -a "$GITHUB_ENV"
 
       - name: Pack and upload to charmhub
-        uses: canonical/charming-actions/upload-charm@2.6.2
+        uses: canonical/charming-actions/upload-charm@2.7.0
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,6 @@ jobs:
     uses: ./.github/workflows/check.yaml
     secrets: inherit
 
-
   release:
     needs: check
     runs-on: ubuntu-24.04


### PR DESCRIPTION
- upload the tested charms as an artifacts during check workflow
- download the tested charms and avoid rebuilding the charm when releasing 